### PR TITLE
feat: adding waitUntil to runPuppet

### DIFF
--- a/core/util/runPuppet.js
+++ b/core/util/runPuppet.js
@@ -124,7 +124,12 @@ async function processScenarioView (scenario, variantOrScenarioLabelSafe, scenar
     if (isReference && scenario.referenceUrl) {
       url = scenario.referenceUrl;
     }
-    await page.goto(translateUrl(url));
+
+    // Page goto options
+    await page.goto(translateUrl(url), {
+      timeout: config.scenarioTimeOut || 1000,  // default is 1ms
+      waitUntil: config.waitUntil || 'default' // default
+    });
 
     await injectBackstopTools(page);
 

--- a/core/util/runPuppet.js
+++ b/core/util/runPuppet.js
@@ -125,9 +125,10 @@ async function processScenarioView (scenario, variantOrScenarioLabelSafe, scenar
       url = scenario.referenceUrl;
     }
 
+    // Full docs for Puppeteer waituntil: https://pptr.dev/#?product=Puppeteer&version=v2.1.1&show=api-pagewaitfornavigationoptions
     // Page goto options
     await page.goto(translateUrl(url), {
-      timeout: config.scenarioTimeOut || 1000,  // default is 1ms
+      timeout: config.scenarioTimeOut || 1000,  // default is 1s
       waitUntil: config.waitUntil || 'default' // default
     });
 


### PR DESCRIPTION
under `config` a test now can wait until:

- `networkidle0`
- `networkidle2`
- `default`= default
Full docs for waituntil: https://pptr.dev/#?product=Puppeteer&version=v2.1.1&show=api-pagewaitfornavigationoptions

There is also now wa timeout setting that is by default `1000`. No timeout = 0;


